### PR TITLE
fix for ChangeFailPercentage formula

### DIFF
--- a/helpers/metric_helper.go
+++ b/helpers/metric_helper.go
@@ -47,7 +47,8 @@ func GetChangeFailPercentage(metricTags []tagMetricData) []tagMetricData {
 			totalFeatureCount += len(metricTags[i].featCommits)
 		}
 		if totalFeatureCount != 0 {
-			metricTags[i].tagChangeFailPercentage = float64(totalFixCount) / float64(totalFeatureCount) * 100
+                        totalCommits := float64(totalFixCount) + float64(totalFeatureCount)
+			metricTags[i].tagChangeFailPercentage = 100 * float64(totalFixCount) / totalCommits
 		}
 	}
 


### PR DESCRIPTION
Having total number of commits (100%) were trying to get how much of those are fix commits,
With current calculation you can easily have 400-600% of ChangeFailPercentage